### PR TITLE
CustomField Parser can remove empty strings

### DIFF
--- a/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldApiParser.java
+++ b/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldApiParser.java
@@ -247,10 +247,22 @@ public class CustomFieldApiParser {
                         return text;
                     }
                     final int start = index + "name=".length();
-                    final int end = text.indexOf(",", start);
+                    final int end = text.indexOf(',', start);
                     return text.substring(start, end >= start ? end : text.length());
                 } else if (definition.getSplit() != SplitRule.NONE && StringUtils.isNotEmpty(definition.getSeparator())) {
-                    return text.replaceAll(definition.getSplit().getSplitPattern(), definition.getSeparator());
+                    final String replaced = text.replaceAll(definition.getSplit().getSplitPattern(), definition.getSeparator());
+                    if (definition.getSplitConfig().removeEmptyStrings() && StringUtils.isNotEmpty(definition.getSeparator())) {
+                        final String quotedSeparator = Pattern.quote(definition.getSeparator());
+                        return replaced
+                                // Replace leading and trailing separators with the empty string
+                                .replaceAll(String.format("(?:^%1$s)|(?:%1$s$)", quotedSeparator), "")
+                                // Replace any number of repeated separators with a single one
+                                .replaceAll(String.format("%1$s%1$s+", quotedSeparator), definition.getSeparator())
+                                ;
+
+                    } else {
+                        return replaced;
+                    }
                 } else {
                     return text;
                 }

--- a/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldDefinition.java
+++ b/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldDefinition.java
@@ -1,22 +1,18 @@
 package com.indeed.jiraactions.api.customfields;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
-
-import org.apache.commons.lang.StringUtils;
 import org.immutables.value.Value;
 
 import java.util.List;
 
 @Value.Immutable
+@Value.Style(defaultAsDefault = true)
 @JsonSerialize(as = ImmutableCustomFieldDefinition.class)
 @JsonDeserialize(as = ImmutableCustomFieldDefinition.class)
 public interface CustomFieldDefinition {
-    /* This is a bit of a kludge. When Jackson 2.9 comes out, it adds direct support to do this:
-     * https://stackoverflow.com/a/44217670/1515497
-     */
     enum MultiValueFieldConfiguration {
         /** Split result into two fields (suffixed 1 and 2) */
         SEPARATE,
@@ -25,27 +21,23 @@ public interface CustomFieldDefinition {
         USERNAME, // This is kind of a kludge because it doesn't fit the other types of multi-values, but it keeps the model clean
         /** Expand string values in ISO date-time format into three fields for yyyyMMdd, yyyyMMddHHmmss, and timestamp */
         DATETIME, // Equally kludgy to USERNAME. Consider refactoring.
-        NONE;
 
-        @JsonCreator
-        public static MultiValueFieldConfiguration fromString(final String key) {
-            return StringUtils.isEmpty(key) ? NONE : MultiValueFieldConfiguration.valueOf(key.toUpperCase());
-        }
+        @JsonEnumDefaultValue
+        NONE;
     }
 
     enum Transformation {
         MULTIPLY_BY_THOUSAND,
         FIRST_NUMBER,
-        NONE;
 
-        @JsonCreator
-        public static Transformation fromString(final String key) {
-            return StringUtils.isEmpty(key) ? NONE : Transformation.valueOf(key.toUpperCase());
-        }
+        @JsonEnumDefaultValue
+        NONE;
     }
 
     enum SplitRule {
         NON_NUMBER("\\D+"),
+
+        @JsonEnumDefaultValue
         NONE("");
 
         private final String splitPattern;
@@ -57,10 +49,16 @@ public interface CustomFieldDefinition {
         public String getSplitPattern() {
             return splitPattern;
         }
+    }
 
-        @JsonCreator
-        public static SplitRule fromString(final String key) {
-            return StringUtils.isEmpty(key) ? NONE : SplitRule.valueOf(key.toUpperCase());
+    SplitConfig EMPTY_SPLIT_CONFIG = ImmutableSplitConfig.builder().build();
+    @Value.Immutable
+    @Value.Style(defaultAsDefault = true)
+    @JsonSerialize(as = ImmutableSplitConfig.class)
+    @JsonDeserialize(as = ImmutableSplitConfig.class)
+    interface SplitConfig {
+        default boolean removeEmptyStrings() {
+            return false;
         }
     }
 
@@ -68,29 +66,29 @@ public interface CustomFieldDefinition {
     String[] getCustomFieldId();
     String getImhotepFieldName();
 
-    @Value.Default
     default String getSeparator() {
         return "";
     }
 
-    @Value.Default
     default SplitRule getSplit() {
         return SplitRule.NONE;
     }
 
-    @Value.Default
+    String[] EMPTY_ARRAY = new String[0];
     default String[] getAlternateNames() {
-        return new String[] {};
+        return EMPTY_ARRAY;
     }
 
-    @Value.Default
     default MultiValueFieldConfiguration getMultiValueFieldConfiguration() {
         return MultiValueFieldConfiguration.NONE;
     }
 
-    @Value.Default
     default Transformation getTransformation() {
         return Transformation.NONE;
+    }
+
+    default SplitConfig getSplitConfig() {
+        return EMPTY_SPLIT_CONFIG;
     }
 
     default List<String> getHeaders() {

--- a/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldDefinitionParser.java
+++ b/src/main/java/com/indeed/jiraactions/api/customfields/CustomFieldDefinitionParser.java
@@ -16,6 +16,7 @@ public abstract class CustomFieldDefinitionParser {
 
     private final static ObjectMapper mapper = new ObjectMapper()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
     public static CustomFieldDefinition[] parseCustomFields(final InputStream in) throws IOException {

--- a/src/test/java/com/indeed/jiraactions/api/customfields/TestCustomFieldValue.java
+++ b/src/test/java/com/indeed/jiraactions/api/customfields/TestCustomFieldValue.java
@@ -2,6 +2,7 @@ package com.indeed.jiraactions.api.customfields;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.indeed.jiraactions.CustomFieldOutputter;
 import com.indeed.jiraactions.FriendlyUserLookupService;
 import com.indeed.jiraactions.OutputFormatter;
@@ -69,6 +70,15 @@ public class TestCustomFieldValue {
             .imhotepFieldName("allfeedids*|")
             .separator("|")
             .split(CustomFieldDefinition.SplitRule.NON_NUMBER)
+            .build();
+
+    private static final CustomFieldDefinition separatorRemovesEmptySpace = ImmutableCustomFieldDefinition.builder()
+            .name("Separator Removing Empty Space")
+            .customFieldId("customfield_10042")
+            .imhotepFieldName("fieldName*|")
+            .separator("|")
+            .split(CustomFieldDefinition.SplitRule.NON_NUMBER)
+            .splitConfig(ImmutableSplitConfig.builder().removeEmptyStrings(true).build())
             .build();
 
     @Test
@@ -266,6 +276,18 @@ public class TestCustomFieldValue {
 
         Assert.assertEquals("5000", CustomFieldOutputter.numericStringToMilliNumericString("5"));
         Assert.assertEquals("230", CustomFieldOutputter.numericStringToMilliNumericString(".23"));
+    }
+
+    @Test
+    public void testLeavesInEmptySpaces() {
+        final String value = apiParser.customFieldFromInitialFields(feedid, new TextNode("A BUNCH OF NON-NUMERIC TEXT18176487SOME MORE NON-NUMERIC TEXT")).getValue();
+        Assert.assertEquals("|18176487|", value);
+    }
+
+    @Test
+    public void testRemovingEmptySpaces() {
+        final String value = apiParser.customFieldFromInitialFields(separatorRemovesEmptySpace, new TextNode("A BUNCH OF NON-NUMERIC TEXT18176487SOME MORE NON-NUMERIC TEXT")).getValue();
+        Assert.assertEquals("18176487", value);
     }
 
     private void testFromInitial(final CustomFieldDefinition definition, final String input, final String expected) throws IOException {


### PR DESCRIPTION
The CustomFieldDefinition.SplitRule is pretty simple; it just replaces
every single instance of the matched pattern with the replacement. The
problem is that data that unexpectedly does not match at the beginning
or the end of the input can produce output with a leading or trailing
separator. If you're splitting on NON_NUMBER, an input like "abc123def"
produces an output like "|123|". If the field is strictly typed as an
integer, Imhotep will reject it. Thus we need to be configured to
automatically remove those.

Fixes #63