### PR TITLE
Correctly decodes projectkey from issuekey

### DIFF
--- a/src/main/java/com/indeed/jiraactions/api/response/issue/fields/Field.java
+++ b/src/main/java/com/indeed/jiraactions/api/response/issue/fields/Field.java
@@ -70,7 +70,6 @@ public class Field {
             case "creator": return creator == null ? "" : creator.getDisplayName();
             case "issuetype": return issuetype == null ? "" : issuetype.name;
             case "project": return project == null ? "" : project.name;
-            case "projectkey": return project == null ? "" : project.key;
             case "reporter": return reporter == null ? "" : reporter.getDisplayName();
             case "reporterusername": return reporter == null ? "" : reporter.getName();
             case "reporterkey": return reporter == null ? "" : reporter.getKey();

--- a/src/main/java/com/indeed/jiraactions/api/response/issue/fields/Project.java
+++ b/src/main/java/com/indeed/jiraactions/api/response/issue/fields/Project.java
@@ -11,5 +11,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Project {
     public ProjectCategory projectCategory;
     public String name;
-    public String key;
 }

--- a/src/test/java/com/indeed/jiraactions/ActionFactoryTest.java
+++ b/src/test/java/com/indeed/jiraactions/ActionFactoryTest.java
@@ -39,17 +39,17 @@ public class ActionFactoryTest {
     }
 
     @Test
-    /**
+    /*
      * Components that are added to an issue when the issue is first created will never appear in
      *  the changelog. Make sure that we are adding this to the issue.
      */
     public void testComponentsCreatedWithIssue() throws IOException {
-        ActionFactory factory = newActionFactory();
+        final ActionFactory factory = newActionFactory();
 
         try (final InputStream stream = getClass().getResourceAsStream("/ENGPLANS-10.json")) {
             Assert.assertNotNull(stream);
             final JsonNode node = new ObjectMapper().readTree(stream);
-            Issue issue = IssueAPIParser.getObject(node);
+            final Issue issue = IssueAPIParser.getObject(node);
             final Action action = factory.create(issue);
 
             Assert.assertThat(action.getComponents(), is(equalTo(ImmutableList.of("Eng"))));
@@ -62,12 +62,12 @@ public class ActionFactoryTest {
      */
     @Test
     public void testFixVersionsCreatedWithIssueAndAddedLater() throws IOException {
-        ActionFactory factory = newActionFactory();
+        final ActionFactory factory = newActionFactory();
 
         try (final InputStream stream = getClass().getResourceAsStream("/ENGPLANS-10.testMultipleFixVersionsMixedHistory.json")) {
             Assert.assertNotNull(stream);
             final JsonNode node = new ObjectMapper().readTree(stream);
-            Issue issue = IssueAPIParser.getObject(node);
+            final Issue issue = IssueAPIParser.getObject(node);
             Action action = factory.create(issue);
 
             Assert.assertThat(
@@ -87,6 +87,30 @@ public class ActionFactoryTest {
                     action.getFixVersionsJoined(), is(equalTo("Private launch|Public launch")));
 
         }
+    }
+
+    @Test
+    public void testExtractValidProjectKeyFromIssueKey() {
+        final ActionFactory factory = newActionFactory();
+        Assert.assertEquals("ABC", factory.getProjectkeyFromIssuekey("ABC-123"));
+    }
+
+    @Test
+    public void testExtractShortestProjectKeyFromIssueKey() {
+        final ActionFactory factory = newActionFactory();
+        Assert.assertEquals("A", factory.getProjectkeyFromIssuekey("A-189"));
+    }
+
+    @Test
+    public void testExtractMissingProjectKeyFromIssueKey() {
+        final ActionFactory factory = newActionFactory();
+        Assert.assertThrows(IllegalArgumentException.class, () -> factory.getProjectkeyFromIssuekey("-123"));
+    }
+
+    @Test
+    public void testExtractProjectKeyFromMalformedIssueyKey() {
+        final ActionFactory factory = newActionFactory();
+        Assert.assertThrows(IllegalArgumentException.class, () -> factory.getProjectkeyFromIssuekey("123"));
     }
 
     private ActionFactory newActionFactory() {

--- a/src/test/java/com/indeed/jiraactions/ActionTest.java
+++ b/src/test/java/com/indeed/jiraactions/ActionTest.java
@@ -59,6 +59,7 @@ public class ActionTest {
         prevAction = ImmutableAction.builder()
                 .from(defaultAction)
                 .action("create")
+                .issuekey("ABC-123")
                 .timestamp(prevActionTimestamp)
                 .prevstatus("")
                 .status("Pending Triage")


### PR DESCRIPTION
We were previously getting the projectkey from the Project section in
the fields. This worked great until we wanted to see the project key as
it was in history. We were always getting the current one.

This changes to always decoding the project key from the leading
characters in the issuekey.